### PR TITLE
Bugfix for computing Bernstein basis on each element

### DIFF
--- a/lrsplines2D/src/LRBSpline2D.C
+++ b/lrsplines2D/src/LRBSpline2D.C
@@ -497,10 +497,12 @@ vector<double> LRBSpline2D::unitIntervalBernsteinBasis(double start, double stop
     knots.push_back(slope * (mesh_->kval(d,knots_int[i]) - start));
 
   // Get the position of the interval containing [0,1]. We assume that for
-  // some k, knots[k] <= 0.0 and knots[k+1] >= 1.0, and let interval_pos be this k
+  // some k, knots[k] <= 0.0 and knots[k+1] >= 1.0, and let interval_pos be this k.
+  // We use 0.5 instead of 1.0 to break the loop, in order to avoid using tolerances.
+  // Any number in the open interval (0,1) would work.
   int interval_pos;
   for (interval_pos = 0; interval_pos <= deg; ++interval_pos)
-    if (knots[interval_pos + 1] >= 1.0)
+    if (knots[interval_pos + 1] >= 0.5)
       break;
 
   // Prepare array holding the Bernstein basis coefficients.


### PR DESCRIPTION
The comparison of <=1.0 was leading to bugs when the computed knot was only very close to 1 (i.e. ~0.99999999999). Fixed by changing to <=0.5, since we can choose any value in the open interval (0,1), and this way we avoid the need for tolerances.
