### PR TITLE
Added std:: prefixes to the ostreams in the file.

### DIFF
--- a/newmat/include/newmatio.h
+++ b/newmat/include/newmatio.h
@@ -19,9 +19,9 @@ namespace NEWMAT {
 
 /**************************** input/output *****************************/
 
-ostream& operator<<(ostream&, const BaseMatrix&);
+std::ostream& operator<<(std::ostream&, const BaseMatrix&);
 
-ostream& operator<<(ostream&, const GeneralMatrix&);
+std::ostream& operator<<(std::ostream&, const GeneralMatrix&);
 
 
 /*  Use in some old versions of G++ without complete iomanipulators


### PR DESCRIPTION
Makes it easier to build instead of requiring the user to have a using directive.
