### PR TITLE
Fixed bug in subSurface().

### DIFF
--- a/lrsplines2D/CMakeLists.txt
+++ b/lrsplines2D/CMakeLists.txt
@@ -41,6 +41,24 @@ SET_TARGET_PROPERTIES(GoLRspline2D PROPERTIES SOVERSION ${GoTools_ABI_VERSION})
 
 # Apps, examples, tests, ...?
 
+# Apps and tests
+MACRO(ADD_APPS SUBDIR PROPERTY_FOLDER IS_TEST)
+  FILE(GLOB_RECURSE GoLRspline2D_APPS ${SUBDIR}/*.C)
+  FOREACH(app ${GoLRspline2D_APPS})
+    GET_FILENAME_COMPONENT(appname ${app} NAME_WE)
+    ADD_EXECUTABLE(${appname} ${app})
+    TARGET_LINK_LIBRARIES(${appname} GoLRspline2D ${DEPLIBS})
+    SET_TARGET_PROPERTIES(${appname}
+      PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${SUBDIR})
+    SET_PROPERTY(TARGET ${appname}
+      PROPERTY FOLDER "GoLRspline2D/${PROPERTY_FOLDER}")
+    IF(${IS_TEST})
+      ADD_TEST(${appname} ${SUBDIR}/${appname}
+		--log_format=XML --log_level=all --log_sink=../Testing/${appname}.xml)
+    ENDIF(${IS_TEST})
+  ENDFOREACH(app)
+ENDMACRO(ADD_APPS)
+
 IF(GoTools_COMPILE_APPS)
   FILE(GLOB_RECURSE GoLRspline2D_APPS app/*.C)
   FOREACH(app ${GoLRspline2D_APPS})
@@ -66,6 +84,13 @@ IF(GoTools_COMPILE_APPS)
       PROPERTY FOLDER "GoLRspline2D/Examples")
   ENDFOREACH(app)
 ENDIF(GoTools_COMPILE_APPS)
+
+
+IF(GoTools_COMPILE_TESTS)
+  SET(DEPLIBS ${DEPLIBS} ${Boost_LIBRARIES})
+  ADD_APPS(unit_tests "Unit Tests" TRUE)
+  ADD_APPS(regression_tests "Regression Tests" TRUE)
+ENDIF(GoTools_COMPILE_TESTS)
 
 # Symlink data dir.
 execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink ${CMAKE_CURRENT_SOURCE_DIR}/data

--- a/lrsplines2D/src/LRBSpline2D.C
+++ b/lrsplines2D/src/LRBSpline2D.C
@@ -262,9 +262,8 @@ bool LRBSpline2D::operator==(const LRBSpline2D& rhs) const
   int kvec_v_size = kvec_v_.size();
   int kvec_u_size2 = rhs.kvec_u_.size();
   int kvec_v_size2 = rhs.kvec_v_.size();
-  if ((kvec_u_size != 5) || (kvec_v_size != 5) || (kvec_u_size2 != 5) || (kvec_u_size2 != 5))
-    //MESSAGE("DEBUG: Vectors are of different size!");
-    ;
+  if ((kvec_u_size != kvec_u_size2) || (kvec_v_size != kvec_v_size2))
+      MESSAGE("DEBUG: Pairwise vectors are of different size!");
 #endif
 
   const int tmp1 = compare_seq(kvec_u_.begin(), kvec_u_.end(), 

--- a/lrsplines2D/src/LRSplineSurface.C
+++ b/lrsplines2D/src/LRSplineSurface.C
@@ -133,8 +133,8 @@ LRSplineSurface::LRSplineSurface(double knot_tol, bool rational,
 {
   for (size_t ki=0; ki<b_splines.size(); ++ki)
   {
-    // bsplines_[generate_key(*b_splines[ki], mesh_)] = b_splines[ki];
     LRSplineSurface::BSKey bs_key = generate_key(*b_splines[ki], mesh_);
+    b_splines[ki]->setMesh(&mesh_);
     bsplines_.insert(std::pair<LRSplineSurface::BSKey, unique_ptr<LRBSpline2D> >(bs_key, std::move(b_splines[ki])));
   }
 
@@ -496,10 +496,11 @@ void LRSplineSurface::refine(Direction2D d, double fixed_val, double start,
   // affected remain valid after removing and adding elements? If not, this
   // combination of objects and pointers will not work.
     double domain[4];  // Covers elements affected by the split
+    int next_ix = (fixed_ix == mesh_.numDistinctKnots(d) -1) ? fixed_ix : fixed_ix + 1;
     domain[0] = mesh_.kval(XFIXED, (d == XFIXED) ? prev_ix : start_ix);
-    domain[1] = mesh_.kval(XFIXED, (d == XFIXED) ? fixed_ix+1 : end_ix);
+    domain[1] = mesh_.kval(XFIXED, (d == XFIXED) ? next_ix : end_ix);
     domain[2] = mesh_.kval(YFIXED, (d == YFIXED) ? prev_ix : start_ix);
-    domain[3] = mesh_.kval(YFIXED, (d == YFIXED) ? fixed_ix+1 : end_ix);
+    domain[3] = mesh_.kval(YFIXED, (d == YFIXED) ? next_ix : end_ix);
     LRSplineUtils::iteratively_split2(bsplines_affected, mesh_, bsplines_, domain); 
 
 #if 0//ndef NDEBUG
@@ -1350,7 +1351,7 @@ double LRSplineSurface::endparam_v() const
      
      // Perform refinement
      // @@sbr201301 Remove when stable.
-     bool multi_refine = false;
+     bool multi_refine = true;//false;
      if (multi_refine)
        {
 	 sf->refine(refs, true);
@@ -1358,13 +1359,16 @@ double LRSplineSurface::endparam_v() const
      else
        {
 #ifndef NDEBUG
-	 puts("Debugging, remove when code is stable!");
-	 std::swap(refs[0], refs[1]);
+//	 puts("Debugging, remove when code is stable!");
+//	 std::swap(refs[0], refs[1]);
 #endif
 	 for (size_t ki = 0; ki < refs.size(); ++ki)
 	   {
+#ifndef NDEBUG
 	     MESSAGE("ki = " << ki << "\n");
-	     sf->refine(refs[ki], true); // Second argument is 'true', which means that the mult is set to deg+1.
+#endif
+	     sf->refine(refs[ki], true); // Second argument is 'true', which means that the mult is set
+	                                 // to refs[ki].mult = deg+1.
 	   }
        }
 
@@ -1400,7 +1404,6 @@ double LRSplineSurface::endparam_v() const
 	 b_splines2[ki]->setMesh(sub_mesh.get());
 	 b_splines2[ki]->subtractKnotIdx(iu1, iv1);
        }
-     
 
      // Create sub surface
      surf = new LRSplineSurface(knot_tol_, rational_, *sub_mesh, b_splines2);

--- a/lrsplines2D/unit_tests/testLRSplineSurface.C
+++ b/lrsplines2D/unit_tests/testLRSplineSurface.C
@@ -1,0 +1,104 @@
+/*
+* Copyright (C) 1998, 2000-2007, 2010, 2011, 2012, 2013 SINTEF ICT,
+* Applied Mathematics, Norway.
+*
+* Contact information: E-mail: tor.dokken@sintef.no                      
+* SINTEF ICT, Department of Applied Mathematics,                         
+* P.O. Box 124 Blindern,                                                 
+* 0314 Oslo, Norway.                                                     
+*
+* This file is part of GoTools.
+*
+* GoTools is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Affero General Public License as
+* published by the Free Software Foundation, either version 3 of the
+* License, or (at your option) any later version. 
+*
+* GoTools is distributed in the hope that it will be useful,        
+* but WITHOUT ANY WARRANTY; without even the implied warranty of         
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          
+* GNU Affero General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public
+* License along with GoTools. If not, see
+* <http://www.gnu.org/licenses/>.
+*
+* In accordance with Section 7(b) of the GNU Affero General Public
+* License, a covered work must retain the producer line in every data
+* file that is created or manipulated using GoTools.
+*
+* Other Usage
+* You can be released from the requirements of the license by purchasing
+* a commercial license. Buying such a license is mandatory as soon as you
+* develop commercial activities involving the GoTools library without
+* disclosing the source code of your own applications.
+*
+* This file may be used in accordance with the terms contained in a
+* written agreement between you and SINTEF ICT. 
+*/
+
+#define BOOST_TEST_MODULE testLRSplineSurface
+#include <boost/test/unit_test.hpp>
+#include <fstream>
+
+#include "GoTools/lrsplines2D/LRSplineSurface.h"
+#include "GoTools/geometry/ObjectHeader.h"
+
+
+using namespace Go;
+using std::vector;
+using std::string;
+using std::ifstream;
+
+
+struct Config {
+public:
+    Config()
+    {
+
+        datadir = "data/"; // Relative to build/lrsplines2D
+
+        infiles.push_back(datadir + "unit_square_cubic_lr_3d.g2");
+
+    }
+
+public:
+    ObjectHeader header;
+    string datadir;
+    vector<string> infiles;
+    vector<int> numobjects;
+
+};
+
+
+BOOST_FIXTURE_TEST_CASE(testLRSplineSurface, Config)
+{
+    // Assuming all infiles are LRSplineSurface. Otherwise the fixture must be changed.
+    for (auto iter = infiles.begin(); iter != infiles.end(); ++iter)
+    {
+	ifstream in1(iter->c_str());
+	shared_ptr<LRSplineSurface> lr_sf(new LRSplineSurface());
+	header.read(in1);
+	lr_sf->read(in1);
+
+	// lr_sf subSurface() and evaluation in corner point.
+	const double fuzzy = 1e-10;
+	double const umin = 0.9*lr_sf->startparam_u() + 0.1*lr_sf->endparam_u();
+	double const umax = lr_sf->endparam_u();
+	double const vmin = lr_sf->startparam_v();
+	double const vmax = lr_sf->endparam_v();
+	const Point orig_pt = lr_sf->ParamSurface::point(umin, vmin);
+	std::cout << "orig_pt: " << orig_pt[0] << " " << orig_pt[1] << " " << orig_pt[2] << std::endl;
+	// MESSAGE("Calling subSurface().");
+	shared_ptr<LRSplineSurface> sub_sf(lr_sf->subSurface(umin, vmin, umax, vmax, fuzzy));
+	// To provoke memory overwrite we call the function another time.
+//	shared_ptr<LRSplineSurface> sub_sf2(lr_sf->subSurface(umin, vmin, umax, vmax, fuzzy));
+	// MESSAGE("Done calling subSurface().");
+	const Point sub_pt = sub_sf->ParamSurface::point(umin, vmin);
+	std::cout << "sub_pt: " << sub_pt[0] << " " << sub_pt[1] << " " << sub_pt[2] << std::endl;
+	const double dist = orig_pt.dist(sub_pt);
+	std::cout << "dist: " << dist << std::endl;
+	const double tol = 1e-14;
+	BOOST_CHECK_LT(dist, tol);
+    }
+}


### PR DESCRIPTION
The actual bug was inside the LRSplineSurface constructor (called from
subSurface() only) which did not update the LRBSpline2D basis functions
with the mesh set in LRSplineSurface.
Added support for unit testing in lrsplines2D, with the bugfix as the first unit test.
