### PR TITLE
Implemented LRBSpline2D copy constructor

### DIFF
--- a/lrsplines2D/include/GoTools/lrsplines2D/LRBSpline2D.h
+++ b/lrsplines2D/include/GoTools/lrsplines2D/LRBSpline2D.h
@@ -91,6 +91,9 @@ class LRBSpline2D : public Streamable
     mesh_(mesh), coef_fixed_(0)
     {}
 
+  /// Copy constructor
+  LRBSpline2D(const LRBSpline2D& rhs);
+
   /// Swap the contents of two LRBSpline2Ds
   void swap(LRBSpline2D& rhs) 
   {

--- a/lrsplines2D/src/LRBSpline2D.C
+++ b/lrsplines2D/src/LRBSpline2D.C
@@ -204,6 +204,23 @@ double compute_univariate_spline(int deg,
 
 }; // anonymous namespace
 
+
+//==============================================================================
+LRBSpline2D::LRBSpline2D(const LRBSpline2D& rhs)
+//==============================================================================
+{
+  coef_fixed_ = rhs.coef_fixed_;
+  coef_times_gamma_ = rhs.coef_times_gamma_;
+  gamma_ = rhs.gamma_;
+  kvec_u_ = rhs.kvec_u_;
+  kvec_v_ = rhs.kvec_v_;
+  mesh_ = rhs.mesh_;
+  rational_ = rhs.rational_;
+  // don't copy the support
+  weight_ = rhs.weight_;
+
+}
+
 //==============================================================================
 bool LRBSpline2D::operator<(const LRBSpline2D& rhs) const
 //==============================================================================


### PR DESCRIPTION
The copy constructor for LRBSpline2D has been implemented omitting the copy of the support. This fixes the bug in the copy constructor for LRSplineSurface.