### PR TITLE
Fix crash in liftParameterCurve with small tolerance

### DIFF
--- a/gotools-core/src/creators/CurveCreators.C
+++ b/gotools-core/src/creators/CurveCreators.C
@@ -713,6 +713,9 @@ CurveCreators::liftParameterCurve(shared_ptr<ParamCurve>& parameter_cv,
     approximator.refineApproximation();
     shared_ptr<SplineCurve> lifted_cv = approximator.getCurve();
 
+    if (!lifted_cv)
+      return nullptr;
+
 #if _MSC_VER > 0 && _MSC_VER < 1300
     return dynamic_cast<SplineCurve*>(lifted_cv->clone());
 #else


### PR DESCRIPTION
HermiteAppC approximator can return null if the tolerance is too small. In this case, liftParameterCurve should return null instead of trying to clone.