### PR TITLE
Compatibility with musl-libc

### DIFF
--- a/gotools-core/src/utils/timeutils.C
+++ b/gotools-core/src/utils/timeutils.C
@@ -162,7 +162,7 @@ namespace Go {
 #endif
 #else
 #if(__GNUC__ >= 4 && __GNUC_MINOR__ >= 3) 
-	    usleep((__useconds_t)(sleep_time*1e6));
+	    usleep((useconds_t)(sleep_time*1e6));
 #else
 	    usleep(sleep_time*1e6);
 #endif


### PR DESCRIPTION
I'm wanting to compile GoTools on Alpine Linux which uses musl-libc instead of glibc. This very small pull request fixes an issue with this. It also works on my Arch Linux machine with glibc.