### PR TITLE
Macos compile fix

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -148,11 +148,11 @@ Running the tests from a shell (like Git Bash):
 MacOS
 *********
 
-Although we do not have official support for MacOS, GoTools should
-however compile without issues. It has been tested on a MacBook Pro
+Although we do not provide official support for MacOS, GoTools should
+nonetheless compile without issues. It has been tested on MacBook Pro
 (M1 Max) running MacOS Monterey 12.0.1, using the CLion IDE (version
 2021.2.3). It should compile using other IDEs (like XCode) without any
-ssues.
+issues.
 
 We recommend using Homebrew to install the dependencies:
 https://brew.sh

--- a/INSTALL
+++ b/INSTALL
@@ -152,16 +152,20 @@ Although we do not have official support for MacOS, GoTools should
 however compile without issues. It has been tested on a MacBook Pro
 (M1 Max) running MacOS Monterey 12.0.1, using the CLion IDE (version
 2021.2.3). It should compile using other IDEs (like XCode) without any
-issues.
+ssues.
 
-We recommend using Homebrew to install dependencies:
+We recommend using Homebrew to install the dependencies:
 https://brew.sh
 
 All dependencies may then be installed from the command line:
 $ brew install pugixml
 $ brew install boost
 $ brew install qt5
+$ brew install jsoncpp
 
-OpenGL?
-GLUT?
-OpenMP?
+Make sure that QTDIR is set to the base qt folder containing the bin
+and lib dirs, while Qt5_DIR should be set to the folder containing
+the Qt5Config.cmake file (typically $QTDIR/lib/cmake/Qt5/).
+
+There is no default support for OpenMP as it is not supported by Apple
+clang (version 13.0.0).

--- a/INSTALL
+++ b/INSTALL
@@ -143,3 +143,25 @@ Running the tests from a shell (like Git Bash):
 - Run only the acceptance tests (use unit or integration for the other
   test types, using a unique substring like 'cep' will also work):
   $ ctest.exe -L acceptance
+
+
+MacOS
+*********
+
+Although we do not have official support for MacOS, GoTools should
+however compile without issues. It has been tested on a MacBook Pro
+(M1 Max) running MacOS Monterey 12.0.1, using the CLion IDE (version
+2021.2.3). It should compile using other IDEs (like XCode) without any
+issues.
+
+We recommend using Homebrew to install dependencies:
+https://brew.sh
+
+All dependencies may then be installed from the command line:
+$ brew install pugixml
+$ brew install boost
+$ brew install qt5
+
+OpenGL?
+GLUT?
+OpenMP?

--- a/README
+++ b/README
@@ -41,16 +41,17 @@ Requirements:
 * CMake - see: www.cmake.org
 * Linux: Tested with gcc version 4.8. Older versions are not supported.
 * Windows: Tested with Visual Studio 2015 and 2019. Older versions are not supported.
+* MacOS: We do not officially support MacOS. See the INSTALL file for more details.
 
 Dependencies:
 * PugiXML
-* JsonCpp
+* JsonCpp (required for viewlib only)
 * Qt4/Qt5 (required for viewlib only)
 * OpenGL (required for viewlib only)
 * GLUT (required for viewlib only)
+* Boost (required for running the test suite)
 
 Optional dependencies (disabled by default):
-* Boost (required for running the test suite)
 * OpenMP
 
 A few comments on the current distribution:

--- a/README
+++ b/README
@@ -40,8 +40,10 @@ Newmat was written by Robert Davies, http://www.robertnz.com.
 Requirements:
 * CMake - see: www.cmake.org
 * Linux: Tested with gcc version 4.8. Older versions are not supported.
-* Windows: Tested with Visual Studio 2015 and 2019. Older versions are not supported.
-* MacOS: We do not officially support MacOS. See the INSTALL file for more details.
+* Windows: Tested with Visual Studio 2015 and 2019. Older versions are
+  not supported.
+* MacOS: We do not officially support MacOS. It should still work, see
+  the INSTALL file for more details.
 
 Dependencies:
 * PugiXML

--- a/compositemodel/test/acceptance/offsetSurfaceSetTest.C
+++ b/compositemodel/test/acceptance/offsetSurfaceSetTest.C
@@ -68,8 +68,7 @@ using std::ifstream;
 struct Config {
 public:
     Config()
-        : input_filename("tmp/testHermiteApprEvalSurf_input.g2"),
-          output_filename("tmp/testHermiteApprEvalSurf_result.g2")
+        : output_filename("tmp/testHermiteApprEvalSurf_result.g2")
 
     {
 
@@ -195,7 +194,7 @@ public:
     vector<double> offset;
     vector<double> epsgeo;
     ObjectHeader header;
-    const std::string input_filename;
+    //const std::string input_filename;
     const std::string output_filename;
     // const std::string input_filename("tmp/testHermiteApprEvalSurf_input.g2");
     // const std::string output_filename("tmp/testHermiteApprEvalSurf_result.g2");
@@ -239,13 +238,6 @@ BOOST_FIXTURE_TEST_CASE(offsetSurfaceSet, Config)
 
             Utils::eatwhite(infile);
         }        
-
-        std::ofstream fileout2(input_filename);
-        for (size_t kk = 0; kk < sfs.size(); ++kk)
-        {
-            sfs[kk]->writeStandardHeader(fileout2);
-            sfs[kk]->write(fileout2);
-        }
 
         shared_ptr<SplineSurface> offset_sf;
         OffsetSurfaceStatus status;

--- a/compositemodel/test/acceptance/offsetSurfaceSetTest.C
+++ b/compositemodel/test/acceptance/offsetSurfaceSetTest.C
@@ -68,7 +68,8 @@ using std::ifstream;
 struct Config {
 public:
     Config()
-        : output_filename("tmp/offsetSurfaceSetTest_result.g2")
+        : input_filename("tmp/offsetSurfaceSetTest_input.g2"),
+          output_filename("tmp/offsetSurfaceSetTest_result.g2")
 
     {
 
@@ -194,6 +195,7 @@ public:
     vector<double> offset;
     vector<double> epsgeo;
     ObjectHeader header;
+    const std::string input_filename;
     const std::string output_filename;
 
 };
@@ -235,6 +237,13 @@ BOOST_FIXTURE_TEST_CASE(offsetSurfaceSet, Config)
 
             Utils::eatwhite(infile);
         }        
+
+        std::ofstream fileout2(input_filename);
+        for (size_t kk = 0; kk < sfs.size(); ++kk)
+        {
+            sfs[kk]->writeStandardHeader(fileout2);
+            sfs[kk]->write(fileout2);
+        }
 
         shared_ptr<SplineSurface> offset_sf;
         OffsetSurfaceStatus status;

--- a/compositemodel/test/acceptance/offsetSurfaceSetTest.C
+++ b/compositemodel/test/acceptance/offsetSurfaceSetTest.C
@@ -68,7 +68,7 @@ using std::ifstream;
 struct Config {
 public:
     Config()
-        : output_filename("tmp/testHermiteApprEvalSurf_result.g2")
+        : output_filename("tmp/offsetSurfaceSetTest_result.g2")
 
     {
 
@@ -194,10 +194,7 @@ public:
     vector<double> offset;
     vector<double> epsgeo;
     ObjectHeader header;
-    //const std::string input_filename;
     const std::string output_filename;
-    // const std::string input_filename("tmp/testHermiteApprEvalSurf_input.g2");
-    // const std::string output_filename("tmp/testHermiteApprEvalSurf_result.g2");
 
 };
 

--- a/lrsplines3D/app/testStitch.C
+++ b/lrsplines3D/app/testStitch.C
@@ -94,7 +94,7 @@ int main (int argc, char *argv[]) {
   double vdel = (domain[3]-domain[2])/(double)(split_v+1);
   double wdel = (domain[5]-domain[4])/(double)(split_w+1);
   vector<vector<double> > pc4d_sub((split_u+1)*(split_v+1)*(split_w+1));
-  vector<double[6]> sub_domain((split_u+1)*(split_v+1)*(split_w+1));
+  vector<array<double, 6> > sub_domain((split_u+1)*(split_v+1)*(split_w+1));
   
   // Sort the points according to the w-parameter
   qsort(&pc4d[0], num_pts, 4*sizeof(double), compare_w_par);
@@ -174,7 +174,7 @@ int main (int argc, char *argv[]) {
   for (size_t kh=0; kh<pc4d_sub.size(); ++kh)
     {
       LRVolApprox vol_approx(ncoef, order, ncoef, order, ncoef, order,
-			     pc4d_sub[kh], dim, sub_domain[kh], epsge, mba_level);
+			     pc4d_sub[kh], dim, sub_domain[kh].data(), epsge, mba_level);
   
       double max, average, av_all;
       int num_out;


### PR DESCRIPTION
Compilation fix in testStitch.C: Vector of pure arrays is not allowed, replaced with an array class template.